### PR TITLE
Events overview page

### DIFF
--- a/src/controllers/EventsOverviewPageController.php
+++ b/src/controllers/EventsOverviewPageController.php
@@ -177,6 +177,10 @@ class EventsOverviewPageController extends PageController
     protected function setCustomView(HTTPRequest $request)
     {
         $date = $request->param('ID');
+        $otherDate = $request->param('OtherID');
+		if($otherDate && $this->validateFullDate($otherDate)) {
+			return $this->setRangeView($date, $otherDate);
+		}
         $this->view = $this->getViewType($date, 'default');
         $method = 'set' . ucfirst($this->view) . 'View';
         return $this->$method($date);
@@ -216,6 +220,17 @@ class EventsOverviewPageController extends PageController
      */
     protected function dateMask($date) {
         return preg_replace('/[0-9]/', 'x', $date);
+    }
+
+    /**
+     * Validate that a date parameter is in the corrrect format
+     *
+     * @param string $date
+     * @return boolean
+     */
+    protected function validateFullDate($date)
+    {
+        return preg_match('/^[0-9]{4}-[0-9]{2}-[0-9]{2}$/', $date);
     }
 
     /**
@@ -270,7 +285,7 @@ class EventsOverviewPageController extends PageController
     }
 
     /**
-     * Sedt the view for the given date
+     * Set the view for the given date
      *
      * @param string $date  Start date for event list
      */
@@ -279,6 +294,19 @@ class EventsOverviewPageController extends PageController
         $this->startDate = sfDate::getInstance($date);
         $this->endDate = sfDate::getInstance($date);
         $this->view = 'day';
+    }
+
+    /**
+     * Sedt the view for a custom range
+     *
+     * @param string $startDate  Start date for the range
+     * @param string $endDate    Start date for the range
+     */
+    protected function setRangeView($startDate, $endDate)
+    {
+        $this->startDate = sfDate::getInstance($startDate);
+        $this->endDate = sfDate::getInstance($endDate);
+        $this->view = 'range';
     }
 
     /**
@@ -329,6 +357,16 @@ class EventsOverviewPageController extends PageController
     protected function getDayEventsHeader()
     {
         return $this->startDate->format('j F Y');
+    }
+
+    /**
+     * Get the custom range view header text
+     *
+     * @return string
+     */
+    protected function getRangeEventsHeader()
+    {
+        return $this->startDate->format('j F Y') . ' - ' . $this->endDate->format('j F Y');
     }
 
     /**

--- a/src/controllers/EventsOverviewPageController.php
+++ b/src/controllers/EventsOverviewPageController.php
@@ -43,11 +43,13 @@ class EventsOverviewPageController extends PageController
     protected $view = 'default';
 
     /**
-     * Map lengths of date parameters to view types
+     * Map date parameters to view types
+     *
+     * @var array
      */
-    protected $viewDateLengthMap = [
-        '5' => 'today',
-        '7' => 'month',
+    protected $viewTypeMap = [
+        'today'   => 'today',
+        'xxxx-xx' => 'month',
     ];
 
     /**
@@ -172,23 +174,45 @@ class EventsOverviewPageController extends PageController
     protected function setCustomView(HTTPRequest $request)
     {
         $date = $request->param('ID');
-        $this->view = $this->getViewType(strlen($date), 'default');
+        $this->view = $this->getViewType($date, 'default');
         $method = 'set' . ucfirst($this->view) . 'View';
         return $this->$method($date);
     }
 
     /**
-     * Get type of view from date length map
+     * Get type of view from map
      *
      * @param  int    $index     Index into map
-     * @param  string $default   Deault value to return if $index does note exist
+     * @param  string $default   Deault value to return if $index does not exist
      *
      * @return string
      */
     public function getViewType($index, $default) {
-        return (isset($this->viewDateLengthMap[$index]))
-            ? $this->viewDateLengthMap[$index]
-            : $default;
+        $type = $default;
+
+        if (isset($this->viewTypeMap[$index])) {
+            $type = $this->viewTypeMap[$index];
+        } else {
+            $dateMask = $this->dateMask($index);
+            if (isset($this->viewTypeMap[$dateMask])) {
+                $type = $this->viewTypeMap[$dateMask];
+            }
+        }
+
+        return $type;
+    }
+
+    /**
+     * Convert a date format string into a mask.
+     *
+     * E.g. 2018-11-15 => xxxx-xx-xx
+     *
+     * @param  string $date
+     *
+     * @return string
+     */
+    protected function dateMask($date) {
+        return preg_replace('/[0-9]/', 'x', $date);
     }
 
     /**
@@ -254,7 +278,7 @@ class EventsOverviewPageController extends PageController
      */
     protected function getTodayEventsHeader()
     {
-        return $this->startDate->format('d F Y');
+        return $this->startDate->format('j F Y');
     }
 
     /**

--- a/src/controllers/EventsOverviewPageController.php
+++ b/src/controllers/EventsOverviewPageController.php
@@ -49,6 +49,8 @@ class EventsOverviewPageController extends PageController
      */
     protected $viewTypeMap = [
         'today'   => 'today',
+        'week'    => 'week',
+        'month'   => 'week',
         'xxxx-xx' => 'month',
     ];
 
@@ -233,10 +235,25 @@ class EventsOverviewPageController extends PageController
      */
     protected function setMonthView($date)
     {
-        $startOfMonth = "{$date}-01";
-        $this->startDate = sfDate::getInstance($startOfMonth);
-        $this->endDate = sfDate::getInstance($startOfMonth)->finalDayOfMonth();
+        if ($date == 'month') {
+            $this->startDate = sfDate::getInstance()->firstDayOfMonth();
+        } else {
+            $this->startDate = sfDate::getInstance("{$date}-01");
+        }
+        $this->endDate = sfDate::getInstance($this->startDate)->finalDayOfMonth();
         $this->view = 'month';
+    }
+
+    /**
+     * Set the view for this week
+     *
+     * @param string $_  Not used
+     */
+    protected function setWeekView($_ = null)
+    {
+        $this->startDate = sfDate::getInstance()->firstDayOfWeek();
+        $this->endDate = sfDate::getInstance()->finalDayOfWeek();
+        $this->view = 'week';
     }
 
     /**
@@ -279,6 +296,16 @@ class EventsOverviewPageController extends PageController
     protected function getTodayEventsHeader()
     {
         return $this->startDate->format('j F Y');
+    }
+
+    /**
+     * Get the week view header text
+     *
+     * @return string
+     */
+    protected function getWeekEventsHeader()
+    {
+        return $this->startDate->format('j F Y') . ' - ' . $this->endDate->format('j F Y');
     }
 
     /**

--- a/src/controllers/EventsOverviewPageController.php
+++ b/src/controllers/EventsOverviewPageController.php
@@ -48,10 +48,11 @@ class EventsOverviewPageController extends PageController
      * @var array
      */
     protected $viewTypeMap = [
-        'today'   => 'today',
-        'week'    => 'week',
-        'month'   => 'week',
-        'xxxx-xx' => 'month',
+        'today'      => 'today',
+        'week'       => 'week',
+        'month'      => 'week',
+        'xxxx-xx'    => 'month',
+        'xxxx-xx-xx' => 'day',
     ];
 
     /**
@@ -269,6 +270,18 @@ class EventsOverviewPageController extends PageController
     }
 
     /**
+     * Sedt the view for the given date
+     *
+     * @param string $date  Start date for event list
+     */
+    protected function setDayView($date)
+    {
+        $this->startDate = sfDate::getInstance($date);
+        $this->endDate = sfDate::getInstance($date);
+        $this->view = 'day';
+    }
+
+    /**
      * Get the default header text
      *
      * @return string
@@ -289,6 +302,16 @@ class EventsOverviewPageController extends PageController
     }
 
     /**
+     * Get the week view header text
+     *
+     * @return string
+     */
+    protected function getWeekEventsHeader()
+    {
+        return $this->startDate->format('j F Y') . ' - ' . $this->endDate->format('j F Y');
+    }
+
+    /**
      * Get the today view header text
      *
      * @return string
@@ -299,13 +322,13 @@ class EventsOverviewPageController extends PageController
     }
 
     /**
-     * Get the week view header text
+     * Get the day view header text
      *
      * @return string
      */
-    protected function getWeekEventsHeader()
+    protected function getDayEventsHeader()
     {
-        return $this->startDate->format('j F Y') . ' - ' . $this->endDate->format('j F Y');
+        return $this->startDate->format('j F Y');
     }
 
     /**

--- a/src/controllers/EventsOverviewPageController.php
+++ b/src/controllers/EventsOverviewPageController.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Voyage\Events\Pages;
+
+use PageController;
+use SilverStripe\View\ArrayData;
+use SilverStripe\Control\HTTPRequest;
+use SilverStripe\ORM\FieldType\DBDate;
+use Voyage\Events\Helpers\sfDate;
+
+/**
+ * Events Page Controller
+ */
+class EventsOverviewPageController extends PageController
+{
+    /**
+     * Start date for event range
+     * @var Date
+     */
+	protected $startDate;
+
+    /**
+     * End date for event range
+     * @var Date
+     */
+    protected $endDate;
+
+    /**
+     * @param HTTPRequest $request
+     * @return html
+     */
+    public function index(HTTPRequest $request)
+    {
+        $date = $this->setDefaultView();
+
+        return $this->customise(new ArrayData([
+            'EventStartDate' => $date ? DBDate::create('EventStartDate')->setValue($date) : null
+        ]));
+    }
+
+    /**
+     * Get the list of events for the configured dates and filters
+     *
+     * @return DataList
+     */
+    public function Events()
+    {
+        return $this->data()->getEventList($this->getStartDate(), $this->getEndDate());
+    }
+
+    /**
+     * Get start of date range as a string
+     *
+     * @return string|null
+     */
+    protected function getStartDate()
+    {
+        return ($this->startDate) ? $this->startDate->date() : null;
+    }
+
+    /**
+     * Get end of date range as a string
+     *
+     * @return string|null
+     */
+    protected function getEndDate()
+    {
+        return ($this->endDate) ? $this->endDate->date() : null;
+    }
+
+    /**
+     * Default view if one month from the current date
+     */
+    protected function setDefaultView()
+    {
+		$this->view = "default";
+		$this->startDate = sfDate::getInstance();
+		$this->endDate = sfDate::getInstance()->addMonth(1);
+    }
+}

--- a/src/controllers/EventsOverviewPageController.php
+++ b/src/controllers/EventsOverviewPageController.php
@@ -77,6 +77,17 @@ class EventsOverviewPageController extends PageController
     }
 
     /**
+     * Get the header text for the current view
+     *
+     * @return string
+     */
+    public function EventsHeader()
+    {
+        $method = 'get' . ucfirst($this->view) . 'EventsHeader';
+        return $this->$method();
+    }
+
+    /**
      * Get start of date range as a string
      *
      * @return string|null
@@ -152,5 +163,25 @@ class EventsOverviewPageController extends PageController
         $this->startDate = sfDate::getInstance($startOfMonth);
         $this->endDate = sfDate::getInstance($startOfMonth)->finalDayOfMonth();
         $this->view = 'month';
+    }
+
+    /**
+     * Get the default header text
+     *
+     * @return string
+     */
+    protected function getDefaultEventsHeader()
+    {
+        return $this->DefaultHeader;
+    }
+
+    /**
+     * Get the month view header text
+     *
+     * @return string
+     */
+    protected function getMonthEventsHeader()
+    {
+        return $this->startDate->format('F Y');
     }
 }

--- a/src/controllers/EventsOverviewPageController.php
+++ b/src/controllers/EventsOverviewPageController.php
@@ -69,12 +69,12 @@ class EventsOverviewPageController extends PageController
     }
 
     /**
-     * Default view if one month from the current date
+     * Default view of number of configured months from the current date
      */
     protected function setDefaultView()
     {
 		$this->view = "default";
 		$this->startDate = sfDate::getInstance();
-		$this->endDate = sfDate::getInstance()->addMonth(1);
+		$this->endDate = sfDate::getInstance()->addMonth($this->DefaultFutureMonths);
     }
 }

--- a/src/controllers/EventsOverviewPageController.php
+++ b/src/controllers/EventsOverviewPageController.php
@@ -46,6 +46,7 @@ class EventsOverviewPageController extends PageController
      * Map lengths of date parameters to view types
      */
     protected $viewDateLengthMap = [
+        '5' => 'today',
         '7' => 'month',
     ];
 
@@ -129,6 +130,11 @@ class EventsOverviewPageController extends PageController
         return $this->redirect($this->Link('show').'/' . $data['Month']);
     }
 
+    public function getView()
+    {
+        return $this->view;
+    }
+
     /**
      * Get start of date range as a string
      *
@@ -159,15 +165,6 @@ class EventsOverviewPageController extends PageController
     }
 
     /**
-     * Default view of number of configured months from the current date
-     */
-    protected function setDefaultView($_ = null)
-    {
-        $this->startDate = sfDate::getInstance();
-        $this->endDate = sfDate::getInstance()->addMonth($this->DefaultFutureMonths);
-    }
-
-    /**
      * Set a custom view based on date
      *
      * @param HTTPRequest
@@ -188,10 +185,21 @@ class EventsOverviewPageController extends PageController
      *
      * @return string
      */
-    protected function getViewType($index, $default) {
+    public function getViewType($index, $default) {
         return (isset($this->viewDateLengthMap[$index]))
             ? $this->viewDateLengthMap[$index]
             : $default;
+    }
+
+    /**
+     * Default view of number of configured months from the current date
+     *
+     * @param string $_  Not used
+     */
+    protected function setDefaultView($_ = null)
+    {
+        $this->startDate = sfDate::getInstance();
+        $this->endDate = sfDate::getInstance()->addMonth($this->DefaultFutureMonths);
     }
 
     /**
@@ -205,6 +213,18 @@ class EventsOverviewPageController extends PageController
         $this->startDate = sfDate::getInstance($startOfMonth);
         $this->endDate = sfDate::getInstance($startOfMonth)->finalDayOfMonth();
         $this->view = 'month';
+    }
+
+    /**
+     * Set the view for today
+     *
+     * @param string $_  Not used
+     */
+    protected function setTodayView($_ = null)
+    {
+        $this->startDate = sfDate::getInstance();
+        $this->endDate = sfDate::getInstance();
+        $this->view = 'today';
     }
 
     /**
@@ -225,6 +245,16 @@ class EventsOverviewPageController extends PageController
     protected function getMonthEventsHeader()
     {
         return $this->startDate->format('F Y');
+    }
+
+    /**
+     * Get the today view header text
+     *
+     * @return string
+     */
+    protected function getTodayEventsHeader()
+    {
+        return $this->startDate->format('d F Y');
     }
 
     /**

--- a/src/models/EventDateTime.php
+++ b/src/models/EventDateTime.php
@@ -164,4 +164,20 @@ class EventDateTime extends DataObject
     {
         return $this->obj('EndTime')->Format('h:mm a');
     }
+
+    /**
+     * Format start and end time into a range
+     *
+     * @return string
+     */
+    public function getFormattedTimeRange()
+    {
+        return implode(
+            ' - ',
+            array_filter([
+                $this->getFormattedStartTime(),
+                $this->getFormattedEndTime(),
+            ])
+        );
+    }
 }

--- a/src/pagetypes/EventsOverviewPage.php
+++ b/src/pagetypes/EventsOverviewPage.php
@@ -6,6 +6,7 @@ use Page;
 use Voyage\Events\Helpers\sfDate;
 use Voyage\Events\Models\EventDateTime;
 use SilverStripe\Forms\NumericField;
+use SilverStripe\Forms\TextField;
 use SilverStripe\ORM\DataList;
 use SilverStripe\ORM\ArrayList;
 
@@ -20,10 +21,12 @@ class EventsOverviewPage extends Page
 
     private static $db = [
         'DefaultFutureMonths' => 'Int',
+        'DefaultHeader'       => 'Varchar(150)',
     ];
 
     private static $defaults = [
         'DefaultFutureMonths' => '3',
+        'DefaultHeader'       => 'Upcoming Events',
     ];
 
     /**
@@ -43,6 +46,7 @@ class EventsOverviewPage extends Page
         $configuration = _t('EventsOverviewPage.CONFIGURATION','Configuration');
         $fields->addFieldsToTab("Root.$configuration", [
             NumericField::create('DefaultFutureMonths', _t('EventsOverviewPage.DEFAULTFUTUREMONTHS','Number number of future months to show in default view'))->addExtraClass('defaultFutureMonths'),
+            TextField::create('DefaultHeader', _t('EventsOverviewPage.DEFAULTHEADER','Default header (displays when no date range has been selected)')),
         ]);
 
         return $fields;

--- a/src/pagetypes/EventsOverviewPage.php
+++ b/src/pagetypes/EventsOverviewPage.php
@@ -5,6 +5,7 @@ namespace Voyage\Events\Pages;
 use Page;
 use Voyage\Events\Helpers\sfDate;
 use Voyage\Events\Models\EventDateTime;
+use SilverStripe\Forms\NumericField;
 use SilverStripe\ORM\DataList;
 use SilverStripe\ORM\ArrayList;
 
@@ -16,6 +17,14 @@ class EventsOverviewPage extends Page
     private static $table_name = 'EventsOverviewPage';
 
     private static $reccurring_event_index = 0;
+
+    private static $db = [
+        'DefaultFutureMonths' => 'Int',
+    ];
+
+    private static $defaults = [
+        'DefaultFutureMonths' => '3',
+    ];
 
     /**
      * @var array
@@ -30,6 +39,12 @@ class EventsOverviewPage extends Page
     public function getCMSFields()
     {
         $fields = parent::getCMSFields();
+
+        $configuration = _t('EventsOverviewPage.CONFIGURATION','Configuration');
+        $fields->addFieldsToTab("Root.$configuration", [
+            NumericField::create('DefaultFutureMonths', _t('EventsOverviewPage.DEFAULTFUTUREMONTHS','Number number of future months to show in default view'))->addExtraClass('defaultFutureMonths'),
+        ]);
+
         return $fields;
     }
 

--- a/templates/EventsJumpLinks.ss
+++ b/templates/EventsJumpLinks.ss
@@ -1,0 +1,3 @@
+<div class="event-calendar-next-prev">
+  <a href="$PrevLink">$PrevTitle</a> | <a href="$NextLink">$NextTitle</a>
+</div>

--- a/templates/Includes/EventList.ss
+++ b/templates/Includes/EventList.ss
@@ -2,7 +2,7 @@
 <% loop Events %>
 <li class="vevent clearfix">
   <h3 class="summary"><a class="url" href="$Link">$Event.Title</a></h3>
-  <p class="dates">$FormattedStartDate</p>
+  <p class="dates">$FormattedStartDate $FormattedTimeRange</p>
   <% with Event %>$Content.LimitWordCount(60)<% end_with %> <a href="$Link"><% _t('Calendar.MORE','Read more&hellip;') %></a>
 </li>
 <% end_loop %>

--- a/templates/Includes/EventList.ss
+++ b/templates/Includes/EventList.ss
@@ -1,0 +1,9 @@
+<ul>
+<% loop Events %>
+<li class="vevent clearfix">
+  <h3 class="summary"><a class="url" href="$Link">$Event.Title</a></h3>
+  <p class="dates">$FormattedStartDate</p>
+  <% with Event %>$Content.LimitWordCount(60)<% end_with %> <a href="$Link"><% _t('Calendar.MORE','Read more&hellip;') %></a>
+</li>
+<% end_loop %>
+</ul>

--- a/templates/Includes/EventList.ss
+++ b/templates/Includes/EventList.ss
@@ -1,6 +1,6 @@
 <ul>
 <% loop Events %>
-<li class="vevent clearfix">
+<li class="event">
   <h3 class="summary"><a class="url" href="$Link">$Event.Title</a></h3>
   <p class="dates">$FormattedStartDate $FormattedTimeRange</p>
   <% with Event %>$Content.LimitWordCount(60)<% end_with %> <a href="$Link"><% _t('Calendar.MORE','Read more&hellip;') %></a>

--- a/templates/Includes/EventsHeader.ss
+++ b/templates/Includes/EventsHeader.ss
@@ -1,0 +1,1 @@
+<h2>$EventsHeader</h2>

--- a/templates/Includes/EventsMonthJumper.ss
+++ b/templates/Includes/EventsMonthJumper.ss
@@ -1,0 +1,4 @@
+<div class="event-month-jump">
+    <h3 class="FBold"><% _t('EventsOverviewPage.JUMPTOMONTH', 'Jump to a Month') %></h3>
+    $MonthJumpForm
+</div>

--- a/templates/Includes/EventsQuicknav.ss
+++ b/templates/Includes/EventsQuicknav.ss
@@ -1,3 +1,5 @@
 <ul class="event-overview-quick-nav">
   <li><a href="$Link(show/today)"<% if $View == "today" %> class="current"<% end_if %>><% _t('EventOverviewPage.QUICKNAVTODAY', 'Today') %></a></li>
+  <li><a href="$Link(show/week)"<% if $View == "week" %> class="current"<% end_if %>><% _t('EventOverviewPage.QUICKNAVTODAY', 'This Week') %></a></li>
+  <li><a href="$Link(show/month)"<% if $View == "month" %> class="current"<% end_if %>><% _t('EventOverviewPage.QUICKNAVTODAY', 'This Month') %></a></li>
 </ul>

--- a/templates/Includes/EventsQuicknav.ss
+++ b/templates/Includes/EventsQuicknav.ss
@@ -1,4 +1,5 @@
 <ul class="event-overview-quick-nav">
+  <li><a href="$Link()"<% if $View == "default" %> class="current"<% end_if %>>$Title</a></li>
   <li><a href="$Link(show/today)"<% if $View == "today" %> class="current"<% end_if %>><% _t('EventOverviewPage.QUICKNAVTODAY', 'Today') %></a></li>
   <li><a href="$Link(show/week)"<% if $View == "week" %> class="current"<% end_if %>><% _t('EventOverviewPage.QUICKNAVTODAY', 'This Week') %></a></li>
   <li><a href="$Link(show/month)"<% if $View == "month" %> class="current"<% end_if %>><% _t('EventOverviewPage.QUICKNAVTODAY', 'This Month') %></a></li>

--- a/templates/Includes/EventsQuicknav.ss
+++ b/templates/Includes/EventsQuicknav.ss
@@ -1,0 +1,3 @@
+<ul class="event-overview-quick-nav">
+  <li><a href="$Link(show/today)"<% if $View == "today" %> class="current"<% end_if %>><% _t('EventOverviewPage.QUICKNAVTODAY', 'Today') %></a></li>
+</ul>

--- a/templates/Voyage/Events/Pages/Layout/EventsOverviewPage.ss
+++ b/templates/Voyage/Events/Pages/Layout/EventsOverviewPage.ss
@@ -1,8 +1,10 @@
 <h2>$Title</h2>
 
 <% include EventsHeader %>
+<% include EventsMonthJumper %>
+
 <% if Events %>
-<div id="event-calendar-events">
+<div id="event-overview-events">
   <% include EventList %>
 </div>
 <% else %>

--- a/templates/Voyage/Events/Pages/Layout/EventsOverviewPage.ss
+++ b/templates/Voyage/Events/Pages/Layout/EventsOverviewPage.ss
@@ -3,6 +3,7 @@
 <% include EventsHeader %>
 <% include EventsMonthJumper %>
 <% include EventsQuicknav %>
+$EventJumpLinks
 
 <% if Events %>
 <div id="event-overview-events">

--- a/templates/Voyage/Events/Pages/Layout/EventsOverviewPage.ss
+++ b/templates/Voyage/Events/Pages/Layout/EventsOverviewPage.ss
@@ -1,0 +1,9 @@
+<h2>$Title</h2>
+
+<% if Events %>
+<div id="event-calendar-events">
+  <% include EventList %>
+</div>
+<% else %>
+  <p><% _t('NOEVENTS','There are no events') %>.</p>
+<% end_if %>

--- a/templates/Voyage/Events/Pages/Layout/EventsOverviewPage.ss
+++ b/templates/Voyage/Events/Pages/Layout/EventsOverviewPage.ss
@@ -2,6 +2,7 @@
 
 <% include EventsHeader %>
 <% include EventsMonthJumper %>
+<% include EventsQuicknav %>
 
 <% if Events %>
 <div id="event-overview-events">

--- a/templates/Voyage/Events/Pages/Layout/EventsOverviewPage.ss
+++ b/templates/Voyage/Events/Pages/Layout/EventsOverviewPage.ss
@@ -1,5 +1,6 @@
 <h2>$Title</h2>
 
+<% include EventsHeader %>
 <% if Events %>
 <div id="event-calendar-events">
   <% include EventList %>


### PR DESCRIPTION
Quite a lot going on in here so I hope it hasn't gone beyond the scope of what you originally wanted from the module. This adds:

* Events list on the overview page
* Configuration for the default number of months to display in the events list and the heading to use
* A form for jumping to a particular month
* A "quick nav" with options for jumping to today, this week and this month (and "home")
* If the current range is exactly a day, week, or month then show Previous/Next links

<img width="714" alt="screen shot 2018-11-28 at 5 14 10 pm" src="https://user-images.githubusercontent.com/118558/49128614-0f461b80-f331-11e8-8960-7cb793e72713.png">
